### PR TITLE
Implement OTP Verification

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -23,7 +23,6 @@ func main() {
 	dbPassword := os.Getenv("DB_PASSWORD")
 	dbName := os.Getenv("DB_NAME")
 
-
 	// form conn string for db
 	conn_string := fmt.Sprintf(
 		"host=%s user=%s password=%s dbname=%s port=%s sslmode=disable",
@@ -47,6 +46,7 @@ func main() {
 	})
 
 	e.GET("/sendverificationemail", handlers.VerifyEmail)
+	e.GET("/verifyotp", handlers.VerifyOtp)
 
 	// start server
 	e.Logger.Fatal(e.Start("0.0.0.0:1323"))

--- a/backend/internal/models/user_otp_verification_request.go
+++ b/backend/internal/models/user_otp_verification_request.go
@@ -1,0 +1,6 @@
+package models
+
+type UserOtpVerificationRequest struct {
+	Email string `json:"email" binding:"required,email"`
+	Otp   string `json:"otp" binding:"required"`
+}


### PR DESCRIPTION
OTP verification successfully implemented. 
User can submit a get request with email and otp to /verifyotp, and it scans the redis db for the email with that otp, and verifies the otp in the request with the saved otp in redis.

Returns 401 Unauthorised with the email if otp is not verified, and 200 with the email if otp is verified.